### PR TITLE
added __pycache__ folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 .DS_Store
 *~
 .vscode
-
+__pycache__/


### PR DESCRIPTION
added __pycache__ folder to gitignore as it only contains cached bytecode

no __pycache__ folders are needed as python automatically creates them when a module is loaded
